### PR TITLE
Converted config array into object 

### DIFF
--- a/app/library/Bootstrap/Base.php
+++ b/app/library/Bootstrap/Base.php
@@ -77,7 +77,7 @@ abstract class Base
 
         // instantiate them into the phalcon config
         $config = new Config( $defaultConfig );
-        $config->merge( $localConfig );
+        $config->merge( new Config($localConfig) );
 
         $this->di[ 'config' ] = $config;
     }

--- a/nginx.conf.txt
+++ b/nginx.conf.txt
@@ -1,0 +1,32 @@
+server {
+    listen 80;
+
+    server_name l.pb;
+    root /path/to/Phalcon-BoilerPlate/public;
+    index index.php index.html;
+    try_files $uri $uri/ @rewrite;
+
+    location @rewrite {
+        rewrite ^/(.*)$ /index.php?_url=/$1;
+    }
+
+    ## Images and static content is treated different
+    location ~* ^.+.(jpg|jpeg|svg|gif|css|png|js|ico|xml)$ {
+        access_log        off;
+        expires           360d;
+    }
+
+    location ~ /\.ht {
+        deny  all;
+    }
+
+    # Pass the PHP scripts to FastCGI server
+    location ~ \.php$ {
+        fastcgi_pass   unix:/run/php-fpm/www.sock;
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        include fastcgi_params;
+        fastcgi_param  SCRIPT_FILENAME    $document_root$fastcgi_script_name;
+        # fastcgi_param HTTPS on;
+        fastcgi_param  HTTPS off;
+    }
+}


### PR DESCRIPTION
Hi, 
I converted the $localconfig array into object of type Config. It is now working with Phalcon 2.0.3.
I used an object of anonymous type which I think was introduced in PHP 5.4 . Thus I think it would now be incompatible with php 5.3 and below. But given __modern__ nature of Phalcon, I think anyone who would want to use this would also keep their php version updated. 

I also added an Nginx config sample for anyone who would want to use it.  